### PR TITLE
feat: Adding vpc & kms projects creation terraform scripts

### DIFF
--- a/ekm-over-vpc-onboarding/create-vpc-kms-project/README.md
+++ b/ekm-over-vpc-onboarding/create-vpc-kms-project/README.md
@@ -1,0 +1,31 @@
+# KMS and VPC projects creation module
+
+## Overview
+
+This module provides the Terraform infrastructure project creation for an EKM connection with all the required services enabled.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| billing\_account | Billing Account for the customer | `string` | `""` | no |
+| create\_kms\_project | If true, a project for KMS will be created automatically | `bool` | `true` | no |
+| create\_vpc\_project | If true, a project for VPC will be created automatically | `bool` | `true` | no |
+| folder\_id | (Optional) The ID of the GCP folder to create the projects | `string` | `""` | no |
+| kms\_project\_id | ID of the KMS project you would like to create | `string` | `""` | no |
+| kms\_project\_name | Name of the KMS project you would like to create | `string` | n/a | yes |
+| organization\_id | The ID of the existing GCP organization | `string` | n/a | yes |
+| project\_creator\_member\_email | Email of the user that will be granted permissions to create resources under the projects | `string` | `""` | no |
+| random\_project\_suffix | If true, a suffix of 4 random characters will be appended to project names. Only applies when create project flag is true. | `bool` | `false` | no |
+| vpc\_project\_id | ID of the VPC project, default to same as KMS | `string` | `""` | no |
+| vpc\_project\_name | Name of the VPC project, default to same as KMS | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| kms\_project\_id | ID of the KMS project |
+| vpc\_project\_id | ID of the VPC project |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/ekm-over-vpc-onboarding/create-vpc-kms-project/README.md
+++ b/ekm-over-vpc-onboarding/create-vpc-kms-project/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This module provides the Terraform infrastructure project creation for an EKM connection with all the required services enabled.
+This module provides the project infrastructure setup (creation and/or API services enabling) for an EKM connection with Terraform. Two projects will be created/configured: one for KMS and another for VPC.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/ekm-over-vpc-onboarding/create-vpc-kms-project/main.tf
+++ b/ekm-over-vpc-onboarding/create-vpc-kms-project/main.tf
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#####
+# Script to create project
+#####
+
+locals {
+  apis_to_activate_in_kms_project = [
+    "compute.googleapis.com",
+    "cloudkms.googleapis.com",
+    "servicedirectory.googleapis.com",
+  ]
+
+  apis_to_activate_in_vpc_project = [
+    "compute.googleapis.com",
+    "servicedirectory.googleapis.com",
+  ]
+
+}
+
+# User Credentials (Default: Current logged in user)
+data "google_client_openid_userinfo" "provider_identity" {
+}
+
+# Add permission to create projects
+resource "google_organization_iam_member" "project_create_iam_member" {
+  org_id = var.organization_id
+  role   = "roles/resourcemanager.projectCreator"
+  member = format("user:%s", var.project_creator_member_email == "" ? data.google_client_openid_userinfo.provider_identity.email : var.project_creator_member_email)
+}
+
+# Create KMS and VPC projects if specified
+module "kms_project" {
+  count = var.create_kms_project ? 1 : 0
+
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 14.0"
+
+  project_id                  = var.kms_project_id
+  random_project_id           = var.random_project_suffix
+  disable_services_on_destroy = true
+  org_id                      = var.organization_id
+  folder_id                   = var.folder_id
+  name                        = var.kms_project_name
+  billing_account             = var.billing_account
+  activate_apis               = local.apis_to_activate_in_kms_project
+}
+
+module "vpc_project" {
+  count = var.create_vpc_project ? 1 : 0
+
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 14.0"
+
+  project_id                  = var.vpc_project_id
+  random_project_id           = var.random_project_suffix
+  disable_services_on_destroy = true
+  org_id                      = var.organization_id
+  folder_id                   = var.folder_id
+  name                        = var.vpc_project_name == "" ? var.kms_project_name : var.vpc_project_name
+  billing_account             = var.billing_account
+  activate_apis               = local.apis_to_activate_in_vpc_project
+}
+
+# Enabling APIs when an existing project is provided
+
+resource "google_project_service" "kms_project" {
+  for_each = var.create_kms_project ? toset([]) : toset(local.apis_to_activate_in_kms_project)
+
+  project = var.kms_project_id
+  service = each.value
+}
+
+resource "google_project_service" "vpc_project" {
+  for_each = var.create_vpc_project ? toset([]) : toset(local.apis_to_activate_in_vpc_project)
+
+  project = var.vpc_project_id
+  service = each.value
+}

--- a/ekm-over-vpc-onboarding/create-vpc-kms-project/outputs.tf
+++ b/ekm-over-vpc-onboarding/create-vpc-kms-project/outputs.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "kms_project_id" {
+  description = "ID of the KMS project"
+  value       = var.create_kms_project ? module.kms_project[0].project_id : var.kms_project_id
+}
+
+output "vpc_project_id" {
+  description = "ID of the VPC project"
+  value       = var.create_vpc_project ? module.vpc_project[0].project_id : var.vpc_project_id
+}
+

--- a/ekm-over-vpc-onboarding/create-vpc-kms-project/variables.tf
+++ b/ekm-over-vpc-onboarding/create-vpc-kms-project/variables.tf
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "kms_project_name" {
+  type        = string
+  nullable    = false
+  description = "Name of the KMS project you would like to create"
+}
+
+variable "organization_id" {
+  type        = string
+  nullable    = false
+  description = "The ID of the existing GCP organization"
+}
+
+variable "kms_project_id" {
+  type        = string
+  default     = ""
+  nullable    = false
+  description = "ID of the KMS project you would like to create"
+}
+
+variable "vpc_project_name" {
+  type        = string
+  default     = ""
+  description = "Name of the VPC project, default to same as KMS"
+}
+
+variable "vpc_project_id" {
+  type        = string
+  default     = ""
+  description = "ID of the VPC project, default to same as KMS"
+}
+
+variable "billing_account" {
+  type        = string
+  default     = ""
+  description = "Billing Account for the customer"
+}
+
+variable "project_creator_member_email" {
+  type        = string
+  default     = ""
+  nullable    = true
+  description = "Email of the user that will be granted permissions to create resources under the projects"
+}
+
+variable "folder_id" {
+  type        = string
+  default     = ""
+  description = "(Optional) The ID of the GCP folder to create the projects"
+}
+
+variable "create_kms_project" {
+  type        = bool
+  default     = true
+  description = "If true, a project for KMS will be created automatically"
+}
+
+variable "create_vpc_project" {
+  type        = bool
+  default     = true
+  description = "If true, a project for VPC will be created automatically"
+}
+
+variable "random_project_suffix" {
+  type        = bool
+  default     = false
+  description = "If true, a suffix of 4 random characters will be appended to project names. Only applies when create project flag is true."
+}

--- a/ekm-over-vpc-onboarding/create-vpc-kms-project/versions.tf
+++ b/ekm-over-vpc-onboarding/create-vpc-kms-project/versions.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    # Cloud Run support was added on 3.3.0
+    google = ">= 3.3"
+  }
+}

--- a/ekm-over-vpc-onboarding/create-vpc-kms-project/versions.tf
+++ b/ekm-over-vpc-onboarding/create-vpc-kms-project/versions.tf
@@ -15,10 +15,12 @@
  */
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.5.7"
 
   required_providers {
-    # Cloud Run support was added on 3.3.0
-    google = ">= 3.3"
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.23.0"
+    }
   }
 }


### PR DESCRIPTION
This PR focuses on establishing ekm over vpc onboarding terraform scripts folder. This folder is subdivided into kms&vpc project creation scripts (part of this PR) and resource creation script (followed by the next PR). 